### PR TITLE
named export in system-task, using require

### DIFF
--- a/lib/system-task.js
+++ b/lib/system-task.js
@@ -3,7 +3,7 @@
 
 const fs = require("fs");
 
-module.exports = function(jobs){
+module.exports.taskPath = function taskPath(jobs){
 	for(const job of jobs)
 		exec(...job);
 };
@@ -14,7 +14,7 @@ const OP_DATA = 0b001;
 const OP_STAT = 0b010;
 const OP_REAL = 0b100;
 
-module.exports.op = {
+const op = {
 	open: OP_OPEN,
 	data: OP_DATA,
 	stat: OP_STAT,
@@ -24,7 +24,7 @@ module.exports.op = {
 	[OP_STAT]: {id: "stat", name: "Stats"},
 	[OP_REAL]: {id: "real", name: "Realpath"}
 };
-
+module.exports.op = op;
 
 /**
  * Synchronously execute filesystem operations for a path.

--- a/lib/system-task.js
+++ b/lib/system-task.js
@@ -3,7 +3,7 @@
 
 const fs = require("fs");
 
-function taskPath(jobs){
+module.exports = function(jobs){
 	for(const job of jobs)
 		exec(...job);
 };
@@ -14,7 +14,7 @@ const OP_DATA = 0b001;
 const OP_STAT = 0b010;
 const OP_REAL = 0b100;
 
-const op = {
+module.exports.op = {
 	open: OP_OPEN,
 	data: OP_DATA,
 	stat: OP_STAT,
@@ -24,6 +24,7 @@ const op = {
 	[OP_STAT]: {id: "stat", name: "Stats"},
 	[OP_REAL]: {id: "real", name: "Realpath"}
 };
+
 
 /**
  * Synchronously execute filesystem operations for a path.
@@ -99,9 +100,3 @@ function read(fd, limit = 80){
 	
 	return [data, isComplete];
 }
-
-module.exports = {
-  op,
-	taskPath,
-  default: taskPath,
-};

--- a/lib/system-task.js
+++ b/lib/system-task.js
@@ -14,7 +14,7 @@ const OP_DATA = 0b001;
 const OP_STAT = 0b010;
 const OP_REAL = 0b100;
 
-const op = {
+module.exports.op = {
 	open: OP_OPEN,
 	data: OP_DATA,
 	stat: OP_STAT,
@@ -24,7 +24,6 @@ const op = {
 	[OP_STAT]: {id: "stat", name: "Stats"},
 	[OP_REAL]: {id: "real", name: "Realpath"}
 };
-module.exports.op = op;
 
 /**
  * Synchronously execute filesystem operations for a path.

--- a/lib/system-task.js
+++ b/lib/system-task.js
@@ -3,7 +3,7 @@
 
 const fs = require("fs");
 
-module.exports.taskPath = function taskPath(jobs){
+function taskPath(jobs){
 	for(const job of jobs)
 		exec(...job);
 };
@@ -14,7 +14,7 @@ const OP_DATA = 0b001;
 const OP_STAT = 0b010;
 const OP_REAL = 0b100;
 
-module.exports.op = {
+const op = {
 	open: OP_OPEN,
 	data: OP_DATA,
 	stat: OP_STAT,
@@ -99,3 +99,9 @@ function read(fd, limit = 80){
 	
 	return [data, isComplete];
 }
+
+module.exports = {
+  op,
+	taskPath,
+  default: taskPath,
+};

--- a/lib/system.js
+++ b/lib/system.js
@@ -1,9 +1,7 @@
 "use strict";
 
 const {Task}     = require("atom");
-const taskPath   = require.resolve("./system-task.js");
-const {op}       = require(taskPath);
-
+const {op, taskPath} = require("./system-task")
 
 class System{
 	

--- a/lib/system.js
+++ b/lib/system.js
@@ -1,7 +1,8 @@
 "use strict";
 
 const {Task}     = require("atom");
-const {op, taskPath} = require("./system-task");
+const taskPath = require("./system-task");
+const {op} = require("./system-task");
 
 class System{
 	

--- a/lib/system.js
+++ b/lib/system.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const {Task}     = require("atom");
-const {op, taskPath} = require("./system-task")
+const {op, taskPath} = require("./system-task");
 
 class System{
 	


### PR DESCRIPTION
- using normal `require` instead of dynamic `require`. 
`require.resolve` is slower and is not a first-class function and should be avoided in non-remote situations.
https://www.bennadel.com/blog/3243-using-require-resolve-to-calculate-module-relative-file-paths-in-node-js.htm
> Clearly, the require.resolve() method is doing far more than just generating file paths - it's actually interacting with the file system. As such, it has greater processing overhead and some limitations in the way it can be used.
- This removes the errors that occur when the package is used with a compiler.